### PR TITLE
[BUG] Fix bug on API route observability and logging on Vercel

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
       - run: echo "✅ CI passed, ready to deploy"
 
   preview-deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     needs: check-ci-status
     runs-on: ubuntu-latest
     name: Deploy PR Preview on Vercel

--- a/app.vue
+++ b/app.vue
@@ -1,8 +1,14 @@
 <template>
   <NuxtLayout>
     <NuxtPage />
+    <Analytics />
   </NuxtLayout>
 </template>
+
+
+<script setup>
+import { Analytics } from '@vercel/analytics/vue';
+</script>
 
 <style scoped>
 main {

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -11,8 +11,8 @@ const logger = createLogger({
   ),
   transports: [
     new transports.Console(), // Output to stdout/stderr → visible in Vercel Logs
-    new transports.File({ filename: 'logs/error.log', level: 'error' }), // capture the error logs
-    new transports.File({ filename: 'logs/combined.log' }) // capture all logs
+    new transports.File({ filename: 'tmp/logs/error.log', level: 'error' }), // capture the error logs
+    new transports.File({ filename: 'tmp/logs/combined.log' }) // capture all logs
   ],
   exitOnError: false
 });


### PR DESCRIPTION
## 📌 Description
Added full support for Vercel observability by switching Nitro preset to `'vercel'`, and integrated a reusable Winston logger. The `/api/tasks` route now logs detailed info and errors that are visible directly in the Vercel console per function.

## ✅ Checklist
- [X] ESLint-compliant code
- [X] Unit tests added or updated
- [X] Tests passed successfully (Vitest, Playwright)
- [X] No regression detected
- [ ] Documentation updated if necessary

## 🔍 To which issue this PR is linked to ?
Closes #14 

## 💬 Comments
- `preset: 'vercel'` exposes each API route as a distinct serverless function, enabling clear visibility in Vercel’s **Functions** tab.
- Winston logger writes to `stdout` using a custom formatter with timestamps and metadata.
- Logs are now immediately observable for `/api/tasks` after deployment.
- You can test visibility by calling `/api/tasks` and checking the function logs in the Vercel dashboard.
